### PR TITLE
FS-1723; Clean up bioscfg before deploying

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,13 @@
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.57.2
+  golangci-lint-version: 1.57.2 # use the fixed version to not introduce new linters unexpectedly
 
 linters-settings:
   govet:
     enable:
       - fieldalignment
     auto-fix: true
-    check-shadowing: true
     settings:
       printf:
         funcs:
@@ -47,6 +46,7 @@ linters-settings:
       - wrapperFunc
   gofumpt:
     extra-rules: true
+shadow: true
 
 linters:
   enable:
@@ -65,7 +65,7 @@ linters:
     # additional linters
     - bodyclose
     - gocritic
-    - goerr113
+    - err113
     - goimports
     - revive
     - misspell
@@ -76,14 +76,11 @@ linters:
   enable-all: false
   disable-all: true
 
-run:
-#  build-tags:
-  skip-dirs:
-    - internal/fixtures
-  skip-files:
-    - "(.*/)*.*_test.go"
-
 issues:
+  exclude-dirs:
+    - internal/fixtures
+  exclude-files:
+    - "(.*/)*.*_test.go"
   exclude-rules:
     - linters:
         - gosec

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
               readOnly: true
           env:
           {{- if .Values.env.endpoints.fleetdb.authenticate }}
-            - name: FLIPFLOP_ENDPOINTS_FLEETDB_OIDC_CLIENT_SECRET
+            - name: ENDPOINTS_FLEETDB_OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: bioscfg-secrets

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,8 +5,6 @@ image:
     tag: latest
     url: localhost:5001
 env:
-  test: myTest
-  test1: myFirstTest
   facility: sandbox
   log_level: debug
   concurrency: 5

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,7 @@ func readInFile(v *viper.Viper, cfg *Configuration, path string) error {
 		if err != nil {
 			return errors.Wrap(ErrConfig, err.Error())
 		}
+		defer fh.Close()
 
 		if err = v.ReadConfig(fh); err != nil {
 			return errors.Wrap(ErrConfig, "ReadConfig error:"+err.Error())


### PR DESCRIPTION
#### What does this PR do

- Fix linting config
- Remove test vars from chart
- Add file handler closing
- Renaming ENV var, no need to have a prefix that is the app name
