### PR TITLE
Add SUM and IPMI tools.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,15 @@ RUN ./configure \
 RUN make
 RUN make install
 
+## Get IPMI IANA resource, to prevent dependency on third party servers at runtime.
+WORKDIR /usr/share/misc
+RUN wget https://www.iana.org/assignments/enterprise-numbers.txt
+
 # Build a lean image with dependencies installed.
 FROM debian:12.5-slim
 COPY --from=stage1 /usr/sbin/sum /usr/bin/sum
 COPY --from=stage1 /usr/local/bin/ipmitool /usr/local/bin/ipmitool
+COPY --from=stage1 /usr/share/misc/enterprise-numbers.txt /usr/share/misc/enterprise-numbers.txt
 
 ## Install runtime dependencies
 RUN apt-get update -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12.5-slim as stage1
+FROM debian:12.5-slim AS stage1
 
 # Supermicro SUM
 # Note: If we remove the SUM tool, we can move back to an alpine image. Then also compile bioscfg with CGO_ENABLED=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,76 @@
-FROM alpine:latest
+FROM debian:12.5-slim
+
+# Supermicro SUM
+# Note: If we remove the SUM tool, we can move back to an alpine image. Then also compile bioscfg with CGO_ENABLED=0
+WORKDIR /tmp/sum
+
+## Pre-reqs
+RUN apt-get update
+RUN apt-get install wget -y
+
+## Download
+RUN wget https://www.supermicro.com/Bios/sw_download/698/sum_2.14.0_Linux_x86_64_20240215.tar.gz -O sum.tar.gz
+RUN mkdir -p unzipped
+RUN tar -xvzf sum.tar.gz -C unzipped --strip-components=1
+
+## Install
+RUN cp unzipped/sum /usr/sbin/sum #TODO; smc sum has the same name as the gnu command sum (/usr/bin/sum). So we are overwritting it. Sorry not Sorry.
+RUN chmod +x /usr/bin/sum
+
+## Clean-up
+WORKDIR /tmp
+RUN rm -rf /tmp/sum
+RUN apt-get purge wget -y
+
+# IPMI Tool
+#
+# cherry-pick'ed 1edb0e27e44196d1ebe449aba0b9be22d376bcb6
+# to fix https://github.com/ipmitool/ipmitool/issues/377
+#
+ARG IPMITOOL_REPO=https://github.com/ipmitool/ipmitool.git
+ARG IPMITOOL_COMMIT=19d78782d795d0cf4ceefe655f616210c9143e62
+ARG IPMITOOL_CHERRY_PICK=1edb0e27e44196d1ebe449aba0b9be22d376bcb6
+ARG IPMITOOL_BUILD_DEPENDENCIES="git curl make autoconf automake libtool libreadline-dev"
+
+WORKDIR /tmp/ipmi
+
+## Pre-reqs
+RUN apt-get update
+RUN apt-get install ${IPMITOOL_BUILD_DEPENDENCIES} -y
+
+## Download
+RUN git clone -b master ${IPMITOOL_REPO}
+WORKDIR /tmp/ipmi/ipmitool
+RUN git checkout ${IPMITOOL_COMMIT}
+RUN git config --global user.email "github.ci@doesnot.existorg"
+RUN git cherry-pick ${IPMITOOL_CHERRY_PICK}
+
+## Install
+RUN ./bootstrap
+RUN autoreconf -i
+RUN ./configure \
+    --prefix=/usr/local \
+    --enable-ipmievd \
+    --enable-ipmishell \
+    --enable-intf-lan \
+    --enable-intf-lanplus \
+    --enable-intf-open
+RUN make
+RUN make install
+
+## Install runtime dependencies
+RUN apt-get install libreadline8 --no-install-recommends -y
+
+## Clean-up
+WORKDIR /tmp
+RUN rm -rf /tmp/ipmi
+RUN apt-get purge ${IPMITOOL_BUILD_DEPENDENCIES} -y
+
+# Clean apt
+RUN apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y
+RUN rm -rf /var/lib/apt/lists/\* /tmp/\* /var/tmp/*
+
+# BiosCfg
 
 COPY bioscfg /usr/sbin/bioscfg
 RUN chmod +x /usr/sbin/bioscfg

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ build-linux:
 ifeq ($(GO_VERSION), 0)
 	$(error build requies go version 1.22 or higher)
 endif
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bioscfg \
+	# no CGO_ENABLED=0, because we are using a debian image to support the `sum` tool.
+	GOOS=linux GOARCH=amd64 go build -o bioscfg \
 		-ldflags \
 		"-X $(LDFLAG_LOCATION).GitCommit=$(GIT_COMMIT) \
 		-X $(LDFLAG_LOCATION).GitBranch=$(GIT_BRANCH) \

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,7 @@ build-linux:
 ifeq ($(GO_VERSION), 0)
 	$(error build requies go version 1.22 or higher)
 endif
-	# no CGO_ENABLED=0, because we are using a debian image to support the `sum` tool.
-	GOOS=linux GOARCH=amd64 go build -o bioscfg \
+	CGO_ENABLED=0 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bioscfg \
 		-ldflags \
 		"-X $(LDFLAG_LOCATION).GitCommit=$(GIT_COMMIT) \
 		-X $(LDFLAG_LOCATION).GitBranch=$(GIT_BRANCH) \


### PR DESCRIPTION
- Replace alpine with debian, since the sum tool is a dynamic linked binary, and even alpines gcompat doesn't contain mallopt, which SUM needs.
- Build ipmitool from scratch to get cherry picked bug fixes.

Note: This increases the size of the docker image from 89MB to 220MB.

