### PR TITLE
Dockerfile and bmclib updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM ubuntu:jammy AS stage1
+FROM ubuntu:jammy
 
 # Dell racadm
 WORKDIR /tmp/racadm
 
 ## Install Dependencies
-RUN apt update && apt install -y libssl-dev wget pciutils libargtable2-0
+RUN apt update && apt install -y libssl-dev wget pciutils libargtable2-0 dnsutils iputils-ping
 
 ## Download
 RUN wget -U="Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0" https://dl.dell.com/FOLDER12638439M/1/Dell-iDRACTools-Web-LX-11.3.0.0-795_A00.tar.gz
 RUN tar -xzvf Dell-iDRACTools-Web-LX-11.3.0.0-795_A00.tar.gz
 
-## Workaround to ignore systemctl
+## Workaround to add no-op systemctl, otherwise Dell's debs fail
 RUN echo -e '#!/bin/bash\nexit 0' > /bin/systemctl && chmod +x /bin/systemctl
 
 ## Install racadm
@@ -43,10 +43,7 @@ RUN chmod +x /usr/bin/sum
 WORKDIR /tmp
 RUN rm -rf /tmp/sum
 
-# Build a lean image with dependencies installed.
-FROM ubuntu:jammy
-COPY --from=stage1 / /
-
+# bioscfg
 COPY bioscfg /usr/sbin/bioscfg
 RUN chmod +x /usr/sbin/bioscfg
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,14 @@ WORKDIR /tmp/racadm
 ## Install Dependencies
 RUN apt update && apt install -y libssl-dev wget pciutils libargtable2-0 dnsutils iputils-ping
 
-## Download
+## Download - this requires a user-agent hack since Dell filters non-browser UAs for some reason  ¯\_(ツ)_/¯
 RUN wget -U="Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0" https://dl.dell.com/FOLDER12638439M/1/Dell-iDRACTools-Web-LX-11.3.0.0-795_A00.tar.gz
 RUN tar -xzvf Dell-iDRACTools-Web-LX-11.3.0.0-795_A00.tar.gz
 
-## Workaround to add no-op systemctl, otherwise Dell's debs fail
+## Workaround to add no-op systemctl, otherwise Dell's debs fail with:
+##  installed srvadmin-hapi package post-installation script subprocess returned error exit status 127
+## Digging further revealed the post-install script is attempting to activate a systemd service we don't care
+## about (and docker doesn't do systemd.)
 RUN echo -e '#!/bin/bash\nexit 0' > /bin/systemctl && chmod +x /bin/systemctl
 
 ## Install racadm

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,4 @@ COPY --from=stage1 / /
 COPY bioscfg /usr/sbin/bioscfg
 RUN chmod +x /usr/sbin/bioscfg
 
-#ENTRYPOINT ["/usr/sbin/bioscfg"]
+ENTRYPOINT ["/usr/sbin/bioscfg"]

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ REPO := "https://github.com/metal-toolbox/bioscfg.git"
 .DEFAULT_GOAL := help
 
 ## lint
-lint: 
+lint:
 	golangci-lint run --config .golangci.yml --fix
 
 ## Go test
 test: lint
-	CGO_ENABLED=0 go test -timeout 1m -v -covermode=atomic ./...
+	go test -timeout 1m -v -covermode=atomic ./...
 
 ## Generate mocks
 gen-mock:
@@ -32,7 +32,7 @@ build-linux:
 ifeq ($(GO_VERSION), 0)
 	$(error build requies go version 1.22 or higher)
 endif
-	CGO_ENABLED=0 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bioscfg \
+	GOOS=linux GOARCH=amd64 go build -o bioscfg \
 		-ldflags \
 		"-X $(LDFLAG_LOCATION).GitCommit=$(GIT_COMMIT) \
 		-X $(LDFLAG_LOCATION).GitBranch=$(GIT_BRANCH) \
@@ -42,8 +42,7 @@ endif
 
 ## build docker image and tag as ghcr.io/metal-toolbox/bioscfg:latest
 build-image: build-linux
-	@echo ">>>> NOTE: You may want to execute 'make build-image-nocache' depending on the Docker stages changed"
-	docker buildx build --platform linux/amd64 --rm=true -f Dockerfile -t ${DOCKER_IMAGE}:latest . \
+	docker buildx build --no-cache --platform linux/amd64 --rm=true -f Dockerfile -t ${DOCKER_IMAGE}:latest . \
 		--label org.label-schema.schema-version=1.0 \
 		--label org.label-schema.vcs-ref=$(GIT_COMMIT_FULL) \
 		--label org.label-schema.vcs-url=$(REPO)

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
         k8s-service: bioscfg
     spec:
       terminationGracePeriodSeconds: 1200
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"  # Adjust the value as needed
       containers:
         - name: bioscfg
           image: {{ .Values.image.repository.url }}/bioscfg:{{ .Values.image.repository.tag }}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/jeremywohl/flatten v1.0.1
-	github.com/metal-toolbox/bmclib v1.2.0
+	github.com/metal-toolbox/bmclib v1.2.1
 	github.com/metal-toolbox/ctrl v1.1.0
 	github.com/metal-toolbox/fleetdb v1.20.1
 	github.com/metal-toolbox/rivets/v2 v2.1.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/jeremywohl/flatten v1.0.1
-	github.com/metal-toolbox/bmclib v1.1.2
+	github.com/metal-toolbox/bmclib v1.2.0
 	github.com/metal-toolbox/ctrl v1.1.0
 	github.com/metal-toolbox/fleetdb v1.20.1
 	github.com/metal-toolbox/rivets/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxU
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/metal-toolbox/bmc-common v1.0.3 h1:hrX5Q3k+CrHzUtlN5nh6X9l7l7D3chsHKVM8MQmLjMc=
 github.com/metal-toolbox/bmc-common v1.0.3/go.mod h1:WxMpaNb7/yTSEW0fMDOWUrhs/CPAzuCSx0p3uv3vRVA=
-github.com/metal-toolbox/bmclib v1.1.2 h1:dmD2QhiLeUGN1GtC1z66H94sRnfxOUeA1YO+krOzuZI=
-github.com/metal-toolbox/bmclib v1.1.2/go.mod h1:P4fL5iGJCYjbwUoaUvBJG3Bqa41tfHf8KD975D6vTP4=
+github.com/metal-toolbox/bmclib v1.2.0 h1:goM6Di1hpBOcrUNW5XT+C8ZVQrZVv9X+nFs/kaGraCQ=
+github.com/metal-toolbox/bmclib v1.2.0/go.mod h1:P4fL5iGJCYjbwUoaUvBJG3Bqa41tfHf8KD975D6vTP4=
 github.com/metal-toolbox/conditionorc v1.12.0 h1:goFuCimYEXFoOo6Mbbsai4+STYDn7K/YswvLriYbnlo=
 github.com/metal-toolbox/conditionorc v1.12.0/go.mod h1:5beI/zQYJIZbB77871Fef+jR1It2W4vDIZaIXb7uW/g=
 github.com/metal-toolbox/ctrl v1.1.0 h1:q9pv9G2egtpU9qmOs5WfQ5ZWzOAMIQIsVQpRyVn1hD4=

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxU
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/metal-toolbox/bmc-common v1.0.3 h1:hrX5Q3k+CrHzUtlN5nh6X9l7l7D3chsHKVM8MQmLjMc=
 github.com/metal-toolbox/bmc-common v1.0.3/go.mod h1:WxMpaNb7/yTSEW0fMDOWUrhs/CPAzuCSx0p3uv3vRVA=
-github.com/metal-toolbox/bmclib v1.2.0 h1:goM6Di1hpBOcrUNW5XT+C8ZVQrZVv9X+nFs/kaGraCQ=
-github.com/metal-toolbox/bmclib v1.2.0/go.mod h1:P4fL5iGJCYjbwUoaUvBJG3Bqa41tfHf8KD975D6vTP4=
+github.com/metal-toolbox/bmclib v1.2.1 h1:zb8zXV7hXZ8wtyMx1W5pmO99eFEux1Z96oBQWaWiH1I=
+github.com/metal-toolbox/bmclib v1.2.1/go.mod h1:P4fL5iGJCYjbwUoaUvBJG3Bqa41tfHf8KD975D6vTP4=
 github.com/metal-toolbox/conditionorc v1.12.0 h1:goFuCimYEXFoOo6Mbbsai4+STYDn7K/YswvLriYbnlo=
 github.com/metal-toolbox/conditionorc v1.12.0/go.mod h1:5beI/zQYJIZbB77871Fef+jR1It2W4vDIZaIXb7uW/g=
 github.com/metal-toolbox/ctrl v1.1.0 h1:q9pv9G2egtpU9qmOs5WfQ5ZWzOAMIQIsVQpRyVn1hD4=

--- a/internal/bioscfg/action.go
+++ b/internal/bioscfg/action.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	rctypes "github.com/metal-toolbox/rivets/v2/condition"
 
@@ -17,6 +18,8 @@ func (th *TaskHandler) handleAction(ctx context.Context) error {
 	case rctypes.ResetConfig:
 		return th.resetBiosConfig(ctx)
 	case rctypes.SetConfig:
+		ctx, cancel := context.WithTimeout(ctx, 15*time.Minute)
+		defer cancel()
 		return th.setBiosConfig(ctx)
 	default:
 		return th.failedWithError(ctx, string(th.task.Parameters.Action), errUnsupportedAction)


### PR DESCRIPTION
#### What does this PR do

This is a pretty big change:
- Switching to Ubuntu Jammy (22.04) as the base container, as this is one of the platforms supported by racadm. Also, we're already hacking in glibc for ipmitool and sum so might as well just go all in.
- Instead of building ipmitool, installing the Dell provided one as part of racadm. 
- Updates to the dell apply bios config from file to use the new racadm based implementation in bmclib.